### PR TITLE
Fix Unexpected keyword 'const' on iOS 9

### DIFF
--- a/url.js
+++ b/url.js
@@ -602,7 +602,7 @@ function URLjsImpl() {
   return jURL;
 }
 
-export const URL = URLjsImpl();
+export var URL = URLjsImpl();
 
 /**
  * Helper to feature detect a working native URL implementation


### PR DESCRIPTION
Fix "SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode." on iOS 9
